### PR TITLE
use string to represent mysql text type

### DIFF
--- a/river/sync.go
+++ b/river/sync.go
@@ -160,6 +160,11 @@ func (r *River) makeReqColumnData(col *schema.TableColumn, value interface{}) in
 			}
 			return strings.Join(sets, ",")
 		}
+	case schema.TYPE_STRING:
+		switch value := value.(type) {
+		case []byte:
+			return string(value[:])
+		}
 	}
 
 	return value


### PR DESCRIPTION
use string instead of []byte to represent text ( blob... ) type 