### PR TITLE
Map mysql fields to elasticsearch arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,18 @@ index = "t"
 type = "t"
 parent = "parent_id"
 
-    [[rule.fields]]
-    mysql = "tags"
-    elastic = "tags"
-    type = "list"
+    [rule.field]
+    // This will map column title to elastic search my_title
+    title="my_title"
+
+    // This will map column title to elastic search my_title and use array type
+    title="my_title,list"
+
+    // This will map column title to elastic search title and use array type
+    title=",list"
 ```
 
-This automatically translates a mysql string field like "a,b,c" on an elastic array type '{"a", "b", "c"}' this is specially useful if you need to use those fields on filtering on elasticsearch.
+Modifier "list" will translates a mysql string field like "a,b,c" on an elastic array type '{"a", "b", "c"}' this is specially useful if you need to use those fields on filtering on elasticsearch.
 
 ## Wildcard table
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,32 @@ index = "t"
 type = "t"
 parent = "parent_id"
 
-    [rule.field]
-    title = "my_title"
+    [[rule.fields]]
+    mysql = "title"
+    elastic = "my_title"
 ```
 
 In the example above, we will use a new index and type both named "t" instead of default "t1", and use "my_title" instead of field name "title".
+
+## Rule field types
+
+In order to map a mysql column on different elasticsearch types you can define the field type as follows:
+
+```
+[[rule]]
+schema = "test"
+table = "t1"
+index = "t"
+type = "t"
+parent = "parent_id"
+
+    [[rule.fields]]
+    mysql = "tags"
+    elastic = "tags"
+    type = "list"
+```
+
+This automatically translates a mysql string field like "a,b,c" on an elastic array type '{"a", "b", "c"}' this is specially useful if you need to use those fields on filtering on elasticsearch.
 
 ## Wildcard table
 

--- a/etc/river.toml
+++ b/etc/river.toml
@@ -39,14 +39,13 @@ index = "river"
 type = "river"
 
     # title is MySQL test_river field name, es_title is the customized name in Elasticsearch
-    [[rule.fields]]
-    mysql = "title"
-    elastic = "es_title"
-
-    [[rule.fields]]
-    mysql = "tags"
-    elastic = "tags"
-    type = "list"
+    [rule.field]
+    # This will map column title to elastic search my_title
+    title="es_title"
+    # This will map column tags to elastic search my_tags and use array type
+    tags="my_tags,list"
+    # This will map column keywords to elastic search keywords and use array type
+    keywords=",list"
 
 # wildcard table rule, the wildcard table must be in source tables 
 [[rule]]

--- a/etc/river.toml
+++ b/etc/river.toml
@@ -39,8 +39,14 @@ index = "river"
 type = "river"
 
     # title is MySQL test_river field name, es_title is the customized name in Elasticsearch
-    [rule.field]
-    title = "es_title"
+    [[rule.fields]]
+    mysql = "title"
+    elastic = "es_title"
+
+    [[rule.fields]]
+    mysql = "tags"
+    elastic = "tags"
+    type = "list"
 
 # wildcard table rule, the wildcard table must be in source tables 
 [[rule]]
@@ -50,7 +56,8 @@ index = "river"
 type = "river"
 
     # title is MySQL test_river field name, es_title is the customized name in Elasticsearch
-    [rule.field]
-    title = "es_title"
+    [[rule.fields]]
+    mysql = "title"
+    elastic = "es_title"
 
 

--- a/river/river_test.go
+++ b/river/river_test.go
@@ -70,24 +70,19 @@ func (s *riverTestSuite) SetUpSuite(c *C) {
 
 	cfg.Sources = []SourceConfig{SourceConfig{Schema: "test", Tables: []string{"test_river", "test_river_[0-9]{4}"}}}
 
-	mapping := []*FieldMapping{}
-	mapping = append(mapping, &FieldMapping{Mysql: "mylist", Elastic: "es_mylist", Type: "list"})
-
 	cfg.Rules = []*Rule{
 		&Rule{Schema: "test",
-			Table:              "test_river",
-			Index:              "river",
-			Type:               "river",
-			FieldMapping:       mapping,
-			SingleFieldMapping: map[string]string{"title": "es_title"},
+			Table:        "test_river",
+			Index:        "river",
+			Type:         "river",
+			FieldMapping: map[string]string{"title": "es_title", "mylist": "es_mylist,list"},
 		},
 
 		&Rule{Schema: "test",
-			Table:              "test_river_[0-9]{4}",
-			Index:              "river",
-			Type:               "river",
-			FieldMapping:       mapping,
-			SingleFieldMapping: map[string]string{"title": "es_title"},
+			Table:        "test_river_[0-9]{4}",
+			Index:        "river",
+			Type:         "river",
+			FieldMapping: map[string]string{"title": "es_title", "mylist": "es_mylist,list"},
 		},
 	}
 

--- a/river/river_test.go
+++ b/river/river_test.go
@@ -130,13 +130,9 @@ index = "river"
 type = "river"
 parent = "pid"
 
-    [[rule.fields]]
-    mysql = "title"
-    elastic = "es_title"
-
-    [[rule.fields]]
-    mysql = "mylist"
-    elastic = "es_mylist"
+    [rule.field]
+    title = "es_title"
+    mylist = "es_mylist,list"
 
 [[rule]]
 schema = "test"
@@ -144,13 +140,9 @@ table = "test_river_[0-9]{4}"
 index = "river"
 type = "river"
 
-    [[rule.fields]]
-    mysql = "title"
-    elastic = "es_title"
-
-    [[rule.fields]]
-    mysql = "mylist"
-    elastic = "es_mylist"
+    [rule.field]
+    title = "es_title"
+    mylist = "es_mylist,list"
 
 `
 

--- a/river/river_test.go
+++ b/river/river_test.go
@@ -71,22 +71,23 @@ func (s *riverTestSuite) SetUpSuite(c *C) {
 	cfg.Sources = []SourceConfig{SourceConfig{Schema: "test", Tables: []string{"test_river", "test_river_[0-9]{4}"}}}
 
 	mapping := []*FieldMapping{}
-	mapping = append(mapping, &FieldMapping{Mysql: "title", Elastic: "es_title"})
 	mapping = append(mapping, &FieldMapping{Mysql: "mylist", Elastic: "es_mylist", Type: "list"})
 
 	cfg.Rules = []*Rule{
 		&Rule{Schema: "test",
-			Table:        "test_river",
-			Index:        "river",
-			Type:         "river",
-			FieldMapping: mapping,
+			Table:              "test_river",
+			Index:              "river",
+			Type:               "river",
+			FieldMapping:       mapping,
+			SingleFieldMapping: map[string]string{"title": "es_title"},
 		},
 
 		&Rule{Schema: "test",
-			Table:        "test_river_[0-9]{4}",
-			Index:        "river",
-			Type:         "river",
-			FieldMapping: mapping,
+			Table:              "test_river_[0-9]{4}",
+			Index:              "river",
+			Type:               "river",
+			FieldMapping:       mapping,
+			SingleFieldMapping: map[string]string{"title": "es_title"},
 		},
 	}
 

--- a/river/rule.go
+++ b/river/rule.go
@@ -17,10 +17,16 @@ type Rule struct {
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
 	// but in Elasticsearch, you want to name it my_title.
-	FieldMapping map[string]string `toml:"field"`
+	FieldMapping []*FieldMapping `toml:"fields"`
 
 	// MySQL table information
 	TableInfo *schema.Table
+}
+
+type FieldMapping struct {
+	Mysql   string `toml:"mysql"`
+	Elastic string `toml:"elastic"`
+	Type    string `toml:"type"`
 }
 
 func newDefaultRule(schema string, table string) *Rule {
@@ -30,14 +36,14 @@ func newDefaultRule(schema string, table string) *Rule {
 	r.Table = table
 	r.Index = table
 	r.Type = table
-	r.FieldMapping = make(map[string]string)
+	r.FieldMapping = []*FieldMapping{}
 
 	return r
 }
 
 func (r *Rule) prepare() error {
 	if r.FieldMapping == nil {
-		r.FieldMapping = make(map[string]string)
+		r.FieldMapping = []*FieldMapping{}
 	}
 
 	if len(r.Index) == 0 {

--- a/river/rule.go
+++ b/river/rule.go
@@ -1,6 +1,8 @@
 package river
 
 import (
+	"strings"
+
 	"github.com/siddontang/go-mysql/schema"
 )
 
@@ -17,8 +19,8 @@ type Rule struct {
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
 	// but in Elasticsearch, you want to name it my_title.
-	FieldMapping       []*FieldMapping   `toml:"fields"`
 	SingleFieldMapping map[string]string `toml:"field"`
+	FieldMapping       []*FieldMapping
 
 	// MySQL table information
 	TableInfo *schema.Table
@@ -50,9 +52,16 @@ func (r *Rule) prepare() error {
 
 	if r.SingleFieldMapping != nil {
 		for k, v := range r.SingleFieldMapping {
+			composedField := strings.Split(v, ",")
 			field := FieldMapping{
 				Mysql:   k,
-				Elastic: v,
+				Elastic: composedField[0],
+			}
+			if 0 == len(field.Elastic) {
+				field.Elastic = field.Mysql
+			}
+			if 2 == len(composedField) {
+				field.Type = composedField[1]
 			}
 			r.FieldMapping = append(r.FieldMapping, &field)
 		}

--- a/river/rule.go
+++ b/river/rule.go
@@ -1,8 +1,6 @@
 package river
 
 import (
-	"strings"
-
 	"github.com/siddontang/go-mysql/schema"
 )
 
@@ -19,17 +17,10 @@ type Rule struct {
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
 	// but in Elasticsearch, you want to name it my_title.
-	SingleFieldMapping map[string]string `toml:"field"`
-	FieldMapping       []*FieldMapping
+	FieldMapping map[string]string `toml:"field"`
 
 	// MySQL table information
 	TableInfo *schema.Table
-}
-
-type FieldMapping struct {
-	Mysql   string `toml:"mysql"`
-	Elastic string `toml:"elastic"`
-	Type    string `toml:"type"`
 }
 
 func newDefaultRule(schema string, table string) *Rule {
@@ -39,32 +30,14 @@ func newDefaultRule(schema string, table string) *Rule {
 	r.Table = table
 	r.Index = table
 	r.Type = table
-	r.FieldMapping = []*FieldMapping{}
-	r.SingleFieldMapping = make(map[string]string)
+	r.FieldMapping = make(map[string]string)
 
 	return r
 }
 
 func (r *Rule) prepare() error {
 	if r.FieldMapping == nil {
-		r.FieldMapping = []*FieldMapping{}
-	}
-
-	if r.SingleFieldMapping != nil {
-		for k, v := range r.SingleFieldMapping {
-			composedField := strings.Split(v, ",")
-			field := FieldMapping{
-				Mysql:   k,
-				Elastic: composedField[0],
-			}
-			if 0 == len(field.Elastic) {
-				field.Elastic = field.Mysql
-			}
-			if 2 == len(composedField) {
-				field.Type = composedField[1]
-			}
-			r.FieldMapping = append(r.FieldMapping, &field)
-		}
+		r.FieldMapping = make(map[string]string)
 	}
 
 	if len(r.Index) == 0 {

--- a/river/rule.go
+++ b/river/rule.go
@@ -17,7 +17,8 @@ type Rule struct {
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
 	// but in Elasticsearch, you want to name it my_title.
-	FieldMapping []*FieldMapping `toml:"fields"`
+	FieldMapping       []*FieldMapping   `toml:"fields"`
+	SingleFieldMapping map[string]string `toml:"field"`
 
 	// MySQL table information
 	TableInfo *schema.Table
@@ -37,6 +38,7 @@ func newDefaultRule(schema string, table string) *Rule {
 	r.Index = table
 	r.Type = table
 	r.FieldMapping = []*FieldMapping{}
+	r.SingleFieldMapping = make(map[string]string)
 
 	return r
 }
@@ -44,6 +46,16 @@ func newDefaultRule(schema string, table string) *Rule {
 func (r *Rule) prepare() error {
 	if r.FieldMapping == nil {
 		r.FieldMapping = []*FieldMapping{}
+	}
+
+	if r.SingleFieldMapping != nil {
+		for k, v := range r.SingleFieldMapping {
+			field := FieldMapping{
+				Mysql:   k,
+				Elastic: v,
+			}
+			r.FieldMapping = append(r.FieldMapping, &field)
+		}
 	}
 
 	if len(r.Index) == 0 {


### PR DESCRIPTION
Hey,

First of all I'm not sure if this feature fits on your roadmap, but I needed a way to map mysql data on an elasticsearch's array type, in order to keep it easy to create specific filters on a search.

This is a first approach where you can map a comma separated varchar on an array field of ES. 

*Caution, this feature is not retro-compatible, so definitions for rule.fields had changed a bit, example:

old definition
```
[rule.field]
title = "my_title"
```
new definition
```
[[rule.fields]]
mysql = "title
elastic = "my_title"
```

Additionally you'll be able to define the type as "list" if you want to convert your comma separated varchar on an elastic array. 

Defining a type:
```
[[rule.fields]]
mysql = "title
elastic = "my_title"
type = "list"
```
It will map:
```
title = "a,b,c" # on mysql
```
as:
```
title = '{"a","b","c}' # on elastic
```

Again not sure if this fits on your current roadmap, but it was useful for me, so feel free to add it to your repo :-)
