### PR TITLE
changing BulkResponseItem.Error to json.rawMessage

### DIFF
--- a/elastic/client.go
+++ b/elastic/client.go
@@ -129,7 +129,7 @@ type BulkResponseItem struct {
 	ID      string `json:"_id"`
 	Version int    `json:"_version"`
 	Status  int    `json:"status"`
-	Error   string `json:"error"`
+	Error   json.RawMessage `json:"error"`
 	Found   bool   `json:"found"`
 }
 


### PR DESCRIPTION
With ES 2.3, when BulkResponseItem.Error comes back ES provides a json object
rather than a string.  This causes the json.Unmarshal method to fail and the
application exits.  Treating the response as a json.RawMessage allows
json.Unmarshal to treat all error responses as a string regardless of json
data type.

Resolves issue #40 