### PR TITLE
according to 'http://dev.mysql.com/doc/internals/en/packet-EOF_Packet…

### DIFF
--- a/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
@@ -514,6 +514,8 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 				s.closeWithError(err)
 				return
 			}
+		case EOF_HEADER:
+			log.Infof("EOF package: %v", data)
 		case ERR_HEADER:
 			err = b.c.HandleErrorPacket(data)
 			s.closeWithError(err)

--- a/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
@@ -515,6 +515,8 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 				return
 			}
 		case EOF_HEADER:
+			// according to "http://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html", EOF and OK package serve the same purpose, 
+			// to mark the end of a query execution result. So do nothing, but log the receive data.
 			log.Infof("EOF package: %v", data)
 		case ERR_HEADER:
 			err = b.c.HandleErrorPacket(data)


### PR DESCRIPTION
….html', EOF and OK package serve the same purpose, to mark the end of a query execution result. My MySQL version is 5.7.13, the EOF package is deprecated, but strange the slave still get EOF package from master, so I do nothing but log the data