### PR TITLE
es request with content-type

### DIFF
--- a/elastic/client.go
+++ b/elastic/client.go
@@ -146,6 +146,7 @@ type BulkResponseItem struct {
 
 func (c *Client) DoRequest(method string, url string, body *bytes.Buffer) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, body)
+	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
test failed with `go test --race ./...`
```
➜  go-mysql-elasticsearch git:(master) ✗ go test --race ./...
?   	github.com/siddontang/go-mysql-elasticsearch/cmd/go-mysql-elasticsearch	[no test files]

----------------------------------------------------------------------
FAIL: client_test.go:101: elasticTestSuite.TestParent

client_test.go:112:
    c.Assert(err, IsNil)
... value *errors.Err = &errors.Err{message:"Error: Not Acceptable, code: 406", cause:error(nil), previous:error(nil), file:"/Users/henter/Go/src/github.com/siddontang/go-mysql-elasticsearch/elastic/client.go", line:241} ("Error: Not Acceptable, code: 406")


----------------------------------------------------------------------
FAIL: client_test.go:44: elasticTestSuite.TestSimple

client_test.go:56:
    c.Assert(exists, Equals, true)
... obtained bool = false
... expected bool = true

OOPS: 0 passed, 2 FAILED
--- FAIL: Test (0.08s)
FAIL
FAIL	github.com/siddontang/go-mysql-elasticsearch/elastic	0.112s
2017/09/30 13:34:09 binlogsyncer.go:93: [info] create BinlogSyncer with config &{1001 mysql 127.0.0.1 3306 root   utf8 false false <nil> false info 0}
2017/09/30 13:34:09 status.go:52: [info] run status http server 127.0.0.1:12800

----------------------------------------------------------------------
FAIL: river_test.go:29: riverTestSuite.SetUpSuite

river_test.go:123:
    c.Assert(err, IsNil)
... value *errors.Err = &errors.Err{message:"Error: Not Acceptable, code: 406", cause:error(nil), previous:error(nil), file:"/Users/henter/Go/src/github.com/siddontang/go-mysql-elasticsearch/elastic/client.go", line:264} ("Error: Not Acceptable, code: 406")

2017/09/30 13:34:09 river.go:271: [info] closing river
2017/09/30 13:34:09 canal.go:163: [info] closing canal
2017/09/30 13:34:09 binlogsyncer.go:120: [info] syncer is closing...
2017/09/30 13:34:09 binlogsyncer.go:135: [info] syncer is closed
2017/09/30 13:34:09 master.go:54: [info] save position (, 0)
OOPS: 0 passed, 1 FAILED, 3 MISSED
--- FAIL: Test (0.40s)
FAIL
FAIL	github.com/siddontang/go-mysql-elasticsearch/river	0.427s
```


error message from Elasticsearch:
`
Elasticsearch-5.6.0-781a835 "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header."
`

