### PR TITLE
Ignore table without primary key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ filter = ["id", "name"]
 
 In the above example, we will only sync MySQL table tfiler's columns `id` and `name` to Elasticsearch. 
 
+## Ignore table without primary key
+When you sync table without primary key, you can see below error message.
+```
+.../go-mysql-elasticsearch/river/river.go:244: schema.table must have a PK for a column
+```
+If you want to ignore table without primary key, you can ignore by adding this attribute to the *.toml.  
+
+```
+# Ignore table without primary key
+skip_non_pk = true
+```
+
 ## Why not other rivers?
 
 Although there are some other MySQL rivers for Elasticsearch, like [elasticsearch-river-jdbc](https://github.com/jprante/elasticsearch-river-jdbc), [elasticsearch-river-mysql](https://github.com/scharron/elasticsearch-river-mysql), I still want to build a new one with Go, why?

--- a/README.md
+++ b/README.md
@@ -150,16 +150,15 @@ filter = ["id", "name"]
 
 In the above example, we will only sync MySQL table tfiler's columns `id` and `name` to Elasticsearch. 
 
-## Ignore table without primary key
-When you sync table without primary key, you can see below error message.
+## Ignore table without a primary key
+When you sync table without a primary key, you can see below error message.
 ```
-.../go-mysql-elasticsearch/river/river.go:244: schema.table must have a PK for a column
+schema.table must have a PK for a column
 ```
-If you want to ignore table without primary key, you can ignore by adding this attribute to the *.toml.  
-
+You can ignore these tables in the configuration like:
 ```
-# Ignore table without primary key
-skip_non_pk = true
+# Ignore table without a primary key
+skip_no_pk_table = true
 ```
 
 ## Why not other rivers?

--- a/etc/river.toml
+++ b/etc/river.toml
@@ -40,7 +40,7 @@ bulk_size = 128
 flush_bulk_time = "200ms"
 
 # Ignore table without primary key
-skip_non_pk = false
+skip_no_pk_table = false
 
 # MySQL data source
 [[source]]

--- a/etc/river.toml
+++ b/etc/river.toml
@@ -39,6 +39,9 @@ bulk_size = 128
 # force flush the pending requests if we don't have enough items >= bulk_size
 flush_bulk_time = "200ms"
 
+# Ignore table without primary key
+skip_non_pk = false
+
 # MySQL data source
 [[source]]
 schema = "test"

--- a/river/config.go
+++ b/river/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	BulkSize int `toml:"bulk_size"`
 
 	FlushBulkTime TomlDuration `toml:"flush_bulk_time"`
+
+	SkipNonPk bool `toml:"skip_non_pk"`
 }
 
 func NewConfigWithFile(name string) (*Config, error) {

--- a/river/config.go
+++ b/river/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 	FlushBulkTime TomlDuration `toml:"flush_bulk_time"`
 
-	SkipNonPk bool `toml:"skip_non_pk"`
+	SkipNoPkTable bool `toml:"skip_no_pk_table"`
 }
 
 func NewConfigWithFile(name string) (*Config, error) {

--- a/river/river.go
+++ b/river/river.go
@@ -232,16 +232,23 @@ func (r *River) prepareRule() error {
 		}
 	}
 
-	for _, rule := range r.rules {
+	rules := make(map[string]*Rule)
+	for key, rule := range r.rules {
 		if rule.TableInfo, err = r.canal.GetTable(rule.Schema, rule.Table); err != nil {
 			return errors.Trace(err)
 		}
 
 		if len(rule.TableInfo.PKColumns) == 0 {
-			return errors.Errorf("%s.%s must have a PK for a column", rule.Schema, rule.Table)
+			if r.c.SkipNonPk == false {
+				return errors.Errorf("%s.%s must have a PK for a column", rule.Schema, rule.Table)
+			} else {
+				fmt.Printf("ignored table without primary key: %s\n", rule.TableInfo.Name)
+			}
+		} else {
+			rules[key] = rule;
 		}
-
 	}
+	r.rules = rules
 
 	return nil
 }

--- a/river/river.go
+++ b/river/river.go
@@ -239,10 +239,10 @@ func (r *River) prepareRule() error {
 		}
 
 		if len(rule.TableInfo.PKColumns) == 0 {
-			if r.c.SkipNonPk == false {
+			if !r.c.SkipNoPkTable {
 				return errors.Errorf("%s.%s must have a PK for a column", rule.Schema, rule.Table)
 			} else {
-				fmt.Printf("ignored table without primary key: %s\n", rule.TableInfo.Name)
+				log.Errorf("ignored table without a primary key: %s\n", rule.TableInfo.Name)
 			}
 		} else {
 			rules[key] = rule;


### PR DESCRIPTION
When you sync table without primary key,  
some attribute(skip_non_pk) will help you.