### PR TITLE
convert table name to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ tables = ["*"]
 
 ## Rule
 
-By default, go-mysql-elasticsearch will use MySQL table name as the Elasticserach's index and type name, use MySQL table field name as the Elasticserach's field name.
+By default, go-mysql-elasticsearch will use MySQL table name converted to lowercase as the Elasticserach's index and type name, use MySQL table field name as the Elasticserach's field name.  
 e.g, if a table named blog, the default index and type in Elasticserach are both named blog, if the table field named title,
 the default field name is also named title.
 

--- a/river/river.go
+++ b/river/river.go
@@ -1,6 +1,7 @@
 package river
 
 import (
+	"strings"
 	"context"
 	"fmt"
 	"regexp"
@@ -258,7 +259,7 @@ func (r *River) prepareRule() error {
 }
 
 func ruleKey(schema string, table string) string {
-	return fmt.Sprintf("%s:%s", schema, table)
+	return strings.ToLower(fmt.Sprintf("%s:%s", schema, table))
 }
 
 // Run syncs the data from MySQL and inserts to ES.

--- a/river/rule.go
+++ b/river/rule.go
@@ -34,8 +34,11 @@ func newDefaultRule(schema string, table string) *Rule {
 
 	r.Schema = schema
 	r.Table = table
-	r.Index = table
-	r.Type = table
+
+	lowerTable := strings.ToLower(table)
+	r.Index = lowerTable
+	r.Type = lowerTable
+
 	r.FieldMapping = make(map[string]string)
 
 	return r

--- a/river/rule.go
+++ b/river/rule.go
@@ -1,6 +1,8 @@
 package river
 
 import (
+	"strings"
+
 	"github.com/siddontang/go-mysql/schema"
 )
 
@@ -8,12 +10,12 @@ import (
 // The mapping rule may thi: schema + table <-> index + document type.
 // schema and table is for MySQL, index and document type is for Elasticsearch.
 type Rule struct {
-	Schema string `toml:"schema"`
-	Table  string `toml:"table"`
-	Index  string `toml:"index"`
-	Type   string `toml:"type"`
-	Parent string `toml:"parent"`
-	ID []string `toml:"id"`
+	Schema string   `toml:"schema"`
+	Table  string   `toml:"table"`
+	Index  string   `toml:"index"`
+	Type   string   `toml:"type"`
+	Parent string   `toml:"parent"`
+	ID     []string `toml:"id"`
 
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
@@ -51,6 +53,11 @@ func (r *Rule) prepare() error {
 	if len(r.Type) == 0 {
 		r.Type = r.Index
 	}
+
+	// ES must use a lower-case Type
+	// Here we also use for Index
+	r.Index = strings.ToLower(r.Index)
+	r.Type = strings.ToLower(r.Type)
 
 	return nil
 }


### PR DESCRIPTION
When capitalizing the table name in the *.toml file as shown below
```
tables = ["TABLE"]
```
you will see the error code below
```
ERRO[0000] index index: TABLE, type: TABLE, id: 1, status: 400, error: {"type":"invalid_index_name_exception","reason":"Invalid index name [TABLE], must be lowercase","index_uuid":"_na_","index":"TABLE"} 
```

so this feature forces the table name to be lowercase and specified as the index and type name of the ES
