### PR TITLE
add config for insert data into the same index for the same schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ You can ignore these tables in the configuration like:
 skip_no_pk_table = true
 ```
 
+## Insert data into the same index for the same schema
+By default, go-mysql-elasticsearch will use MySQL table name as the Elasticserach's index and type name, but if you want to insert data into the same index for the same schema, you should set like blow
+```
+# if you want to insert data into the same index for the same schema
+insert_same_index_same_schema = true
+```
+
 ## Why not other rivers?
 
 Although there are some other MySQL rivers for Elasticsearch, like [elasticsearch-river-jdbc](https://github.com/jprante/elasticsearch-river-jdbc), [elasticsearch-river-mysql](https://github.com/scharron/elasticsearch-river-mysql), I still want to build a new one with Go, why?

--- a/etc/river.toml
+++ b/etc/river.toml
@@ -42,6 +42,9 @@ flush_bulk_time = "200ms"
 # Ignore table without primary key
 skip_no_pk_table = false
 
+# if you want to insert data into the same index for the same schema
+insert_same_index_same_schema = false
+
 # MySQL data source
 [[source]]
 schema = "test"

--- a/river/config.go
+++ b/river/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	FlushBulkTime TomlDuration `toml:"flush_bulk_time"`
 
 	SkipNoPkTable bool `toml:"skip_no_pk_table"`
+	InsertSameIndexSameSchema bool `toml:"insert_same_index_same_schema"`
 }
 
 func NewConfigWithFile(name string) (*Config, error) {

--- a/river/river.go
+++ b/river/river.go
@@ -131,7 +131,7 @@ func (r *River) newRule(schema, table string) error {
 		return errors.Errorf("duplicate source %s, %s defined in config", schema, table)
 	}
 
-	r.rules[key] = newDefaultRule(schema, table)
+	r.rules[key] = newDefaultRule(schema, table, r.c)
 	return nil
 }
 

--- a/river/rule.go
+++ b/river/rule.go
@@ -2,6 +2,7 @@ package river
 
 import (
 	"github.com/siddontang/go-mysql/schema"
+	"strings"
 )
 
 // If you want to sync MySQL data into elasticsearch, you must set a rule to let use know how to do it.
@@ -27,12 +28,18 @@ type Rule struct {
 	Fileter []string `toml:"filter"`
 }
 
-func newDefaultRule(schema string, table string) *Rule {
+func newDefaultRule(schema string, table string, c *Config) *Rule {
 	r := new(Rule)
 
 	r.Schema = schema
 	r.Table = table
-	r.Index = table
+
+	if c.InsertSameIndexSameSchema {
+		r.Index = strings.ToLower(schema)
+	} else {
+		r.Index = table
+	}
+
 	r.Type = table
 	r.FieldMapping = make(map[string]string)
 


### PR DESCRIPTION
By default, go-mysql-elasticsearch will use MySQL table name as the Elasticserach's index and type name, but if you want to insert data into the same index for the same schema, you should set like blow
```
# if you want to insert data into the same index for the same schema
insert_same_index_same_schema = true
```