### PR TITLE
use lowercase for type

### DIFF
--- a/river/river.go
+++ b/river/river.go
@@ -1,6 +1,7 @@
 package river
 
 import (
+	"strings"
 	"context"
 	"fmt"
 	"regexp"
@@ -258,7 +259,7 @@ func (r *River) prepareRule() error {
 }
 
 func ruleKey(schema string, table string) string {
-	return fmt.Sprintf("%s:%s", schema, table)
+	return strings.ToLower(fmt.Sprintf("%s:%s", schema, table))
 }
 
 // Run syncs the data from MySQL and inserts to ES.

--- a/river/rule.go
+++ b/river/rule.go
@@ -1,6 +1,8 @@
 package river
 
 import (
+	"strings"
+
 	"github.com/siddontang/go-mysql/schema"
 )
 
@@ -8,12 +10,12 @@ import (
 // The mapping rule may thi: schema + table <-> index + document type.
 // schema and table is for MySQL, index and document type is for Elasticsearch.
 type Rule struct {
-	Schema string `toml:"schema"`
-	Table  string `toml:"table"`
-	Index  string `toml:"index"`
-	Type   string `toml:"type"`
-	Parent string `toml:"parent"`
-	ID []string `toml:"id"`
+	Schema string   `toml:"schema"`
+	Table  string   `toml:"table"`
+	Index  string   `toml:"index"`
+	Type   string   `toml:"type"`
+	Parent string   `toml:"parent"`
+	ID     []string `toml:"id"`
 
 	// Default, a MySQL table field name is mapped to Elasticsearch field name.
 	// Sometimes, you want to use different name, e.g, the MySQL file name is title,
@@ -51,6 +53,11 @@ func (r *Rule) prepare() error {
 	if len(r.Type) == 0 {
 		r.Type = r.Index
 	}
+
+	// ES must use a lower-case Type
+	// Here we also use for Index
+	r.Index = strings.ToLower(r.Index)
+	r.Type = strings.ToLower(r.Type)
 
 	return nil
 }


### PR DESCRIPTION
I think converting all to the lowercase makes sense. 
to fix https://github.com/siddontang/go-mysql-elasticsearch/issues/176

@perfectacle Can you try it?


