### PR TITLE
fix 404 not found

### DIFF
--- a/river/status.go
+++ b/river/status.go
@@ -61,7 +61,7 @@ func (s *stat) Run(addr string) {
 	srv := http.Server{}
 	mux := http.NewServeMux()
 	mux.Handle("/stat", s)
-	mux.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
+	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	srv.Handler = mux
 
 	srv.Serve(s.l)


### PR DESCRIPTION
Open "http://127.0.0.1:12800/debug/pprof", then click the sublinks, and will get "404 not found".

see https://golang.org/src/net/http/pprof/pprof.go?s=2297:2349#L72