### PR TITLE
add include table regex for canal

### DIFF
--- a/river/river.go
+++ b/river/river.go
@@ -95,6 +95,12 @@ func (r *River) newCanal() error {
 	cfg.Dump.DiscardErr = false
 	cfg.Dump.SkipMasterData = r.c.SkipMasterData
 
+	for _, s := range r.c.Sources {
+		for _, t := range s.Tables {
+			cfg.IncludeTableRegex = append(cfg.IncludeTableRegex, s.Schema+"\\."+t)
+		}
+	}
+
 	var err error
 	r.canal, err = canal.NewCanal(cfg)
 	return errors.Trace(err)


### PR DESCRIPTION
go-mysql/canal/Config provided Options "IncludeTableRegex" and "ExcludeTableRegex",
and we can use those for filter tables.

We only need MySQL read permissions for those tables that we config.
If not add this, and we may read others table columns info by code

call stack
- [err = c.handleRowsEvent(ev)](https://github.com/siddontang/go-mysql/blob/master/canal/sync.go#L81)
- [t, err := c.GetTable(schema, table)](https://github.com/siddontang/go-mysql/blob/master/canal/sync.go#L178)
- [t, err := schema.NewTable(c, db, table)](https://github.com/siddontang/go-mysql/blob/0ad3b7e241bc1658913271288dfe892760a74c57/canal/canal.go#L306)
- [if err := ta.fetchColumns(conn); err != nil {](https://github.com/siddontang/go-mysql/blob/224279b33c33d1621978725510e8287adb4c80df/schema/schema.go#L195)
- [r, err := conn.Execute(fmt.Sprintf("show full columns from `%s`.`%s`", ta.Schema, ta.Name))](https://github.com/siddontang/go-mysql/blob/224279b33c33d1621978725510e8287adb4c80df/schema/schema.go#L207)

after add these code, stack could be break on line

[if !c.checkTableMatch(key) {](https://github.com/siddontang/go-mysql/blob/0ad3b7e241bc1658913271288dfe892760a74c57/canal/canal.go#L286)

this could be better for grant MySQL permissions.

